### PR TITLE
Add support for Node.js version 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ 12, 14 ]
+        node: [ 14, 18 ]
         include:
           - node: 16
             lint: true

--- a/src/server.ts
+++ b/src/server.ts
@@ -144,7 +144,7 @@ export default class Server {
 					}
 					listenStr = address
 				}
-				else if (address.family === 'IPv6') {
+				else if (address.family === 'IPv6' || (typeof address.family === 'number' && address.family === 6)) {
 					listenStr = `[${address.address}]:${address.port}`
 				}
 				else {


### PR DESCRIPTION
It seems like the only breaking change is that `AddressInfo.family` is now a number instead of a string. This affects the return value of `server.address()`, which is used to display the HTTP server's listening address.