### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ 16, 18 ]
+        node: [ 18, 21 ]
         include:
           - node: 20
             lint: true
@@ -20,10 +20,10 @@ jobs:
     name: Build and test (node-${{ matrix.node }})
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
Node version 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/